### PR TITLE
Catch errors on socket write

### DIFF
--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -112,8 +112,12 @@ module.exports = {
     proxyReq.on('response', function (res) {
       // if upgrade event isn't going to happen, close the socket
       if (!res.upgrade && !socket.destroyed) {
-        socket.write(createHttpHeader('HTTP/' + res.httpVersion + ' ' + res.statusCode + ' ' + res.statusMessage, res.headers));
-        res.pipe(socket);
+        try {
+          socket.write(createHttpHeader('HTTP/' + res.httpVersion + ' ' + res.statusCode + ' ' + res.statusMessage, res.headers));
+          res.pipe(socket);
+        } catch (error) {
+          console.error(error)
+        }
       }
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datacamp/http-proxy",
-  "version": "1.18.2",
+  "version": "1.18.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/datacamp-engineering/node-http-proxy.git"


### PR DESCRIPTION
The errors (https://github.com/http-party/node-http-proxy/issues/1432) are still happening, even with https://github.com/http-party/node-http-proxy/pull/1433 in place, so I thought, why not just catch errors and log them but not create a "uncaught error exception"

Ideally this goes to some error handling but I didn't want to have to go so far